### PR TITLE
Bugfix : Fixed XML_TO_XSLX.add so it converts p_vc_addition to utf8

### DIFF
--- a/XML_TO_XSLX.sql
+++ b/XML_TO_XSLX.sql
@@ -506,14 +506,14 @@ is
      
     -- Standard Flow
     IF NVL(LENGTHB(p_vc_buffer), 0) + NVL(LENGTHB(p_vc_addition), 0) < (32767/2) THEN
-      -- Danke für Frank Menne wegen utf-8
+      -- Danke fÃ¼r Frank Menne wegen utf-8
       p_vc_buffer := p_vc_buffer || convert(p_vc_addition,'utf8');
     ELSE
       IF p_clob IS NULL THEN
         dbms_lob.createtemporary(p_clob, TRUE);
       END IF;
       dbms_lob.writeappend(p_clob, length(p_vc_buffer), p_vc_buffer);
-      p_vc_buffer := p_vc_addition;
+      p_vc_buffer := convert(p_vc_addition,'utf8');
     END IF;
      
     -- Full Flush requested

--- a/install_all_packages.sql
+++ b/install_all_packages.sql
@@ -767,6 +767,7 @@ create or replace PACKAGE BODY  IR_TO_XML as
   procedure log(p_message in varchar2,p_eof IN BOOLEAN DEFAULT FALSE)
   is
   begin
+  /* logigging  ffrffe */
     add(v_debug,v_debug_buffer,p_message||chr(10),p_eof);
     apex_debug_message.log_message(p_message => substr(p_message,1,32767),
                                    p_enabled => false,
@@ -2370,14 +2371,14 @@ is
      
     -- Standard Flow
     IF NVL(LENGTHB(p_vc_buffer), 0) + NVL(LENGTHB(p_vc_addition), 0) < (32767/2) THEN
-      -- Danke für Frank Menne wegen utf-8
+      -- Danke fÃ¼r Frank Menne wegen utf-8
       p_vc_buffer := p_vc_buffer || convert(p_vc_addition,'utf8');
     ELSE
       IF p_clob IS NULL THEN
         dbms_lob.createtemporary(p_clob, TRUE);
       END IF;
       dbms_lob.writeappend(p_clob, length(p_vc_buffer), p_vc_buffer);
-      p_vc_buffer := p_vc_addition;
+      p_vc_buffer := convert(p_vc_addition,'utf8');
     END IF;
      
     -- Full Flush requested


### PR DESCRIPTION
XML_TO_XSLX.sql 
- If the p_vc_buffer + p_vc_addition exceded 32767/2 in length, the p_vc_addition would not be converted to utf8, resulting in a corrupt xslx if at that time p_vc_addition contained diacritic signs