### PR TITLE
Fix for LibreOffice and OpenOffice

### DIFF
--- a/IR_TO_XLSX.pkb
+++ b/IR_TO_XLSX.pkb
@@ -2410,7 +2410,7 @@ as
     END LOOP;    
 
     add1file( t_excel, 'xl/styles.xml', get_styles_xml);    
-    add1file( t_excel, 'xl/worksheets/Sheet1.xml', v_cells);
+    add1file( t_excel, 'xl/worksheets/sheet1.xml', v_cells);
     add1file( t_excel, 'xl/sharedStrings.xml',v_strings);
     add1file( t_excel, 'xl/_rels/workbook.xml.rels',t_sheet_rels);    
     add1file( t_excel, 'xl/workbook.xml',t_workbook);    

--- a/install_all_packages.sql
+++ b/install_all_packages.sql
@@ -2996,7 +2996,7 @@ as
     END LOOP;    
 
     add1file( t_excel, 'xl/styles.xml', get_styles_xml);    
-    add1file( t_excel, 'xl/worksheets/Sheet1.xml', v_cells);
+    add1file( t_excel, 'xl/worksheets/sheet1.xml', v_cells);
     add1file( t_excel, 'xl/sharedStrings.xml',v_strings);
     add1file( t_excel, 'xl/_rels/workbook.xml.rels',t_sheet_rels);    
     add1file( t_excel, 'xl/workbook.xml',t_workbook);    


### PR DESCRIPTION
Case-sensitiveness of the Sheet1 is unreadable by LibreOffice.

Source code pointer :
https://opengrok.libreoffice.org/xref/core/oox/source/core/xmlfilterbase.cxx?r=99bc040b#395